### PR TITLE
Update tasks-core dependency to avoid numpy conflict

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     magicgui
     qtpy
     scikit-image
-    fractal-tasks-core==1.0.2
+    fractal-tasks-core==1.3.2
     napari-ome-zarr
     ome-zarr
     wget

--- a/src/napari_ome_zarr_navigator/_tests/test_OMEZarrImage.py
+++ b/src/napari_ome_zarr_navigator/_tests/test_OMEZarrImage.py
@@ -102,7 +102,7 @@ def test_wrong_zarr_urls(zenodo_zarr):
         OMEZarrImage(zarr_but_not_image)
     assert expected_error in str(exc_info.value)
     assert "multiscales" in str(exc_info.value)
-    assert "field required" in str(exc_info.value)
+    assert "Field required" in str(exc_info.value)
 
 
 def test_roi_loading_from_indices(ome_zarr_image_2d):


### PR DESCRIPTION
The current version of the plugin has a version conflict: tasks-core 1.0.2 (which I pinned a while ago for a few minor dependencies) needed numpy<2. But we require numpy==2.0.1 in the plugin.

Updating to a newer version of fractal-tasks-core (1.3.2) should fix this issue (because we only restrict numpy to < 2.1.0 there). It wasn't making any issues in actual usage, but pixi refused to install napari-ome-zarr-navigator because of that conflict.