### PR TITLE
Sort rows and cols before assigning index

### DIFF
--- a/src/napari_ome_zarr_navigator/util.py
+++ b/src/napari_ome_zarr_navigator/util.py
@@ -64,8 +64,8 @@ def calculate_well_positions(plate_url, row, col, is_plate=True):
     image_meta = load_NgffImageMeta(zarr_url)
     scale = image_meta.get_pixel_sizes_zyx(level=level)[-2:]
     plate_meta = load_NgffPlateMeta(plate_url)
-    rows = [x.name for x in plate_meta.plate.rows]
-    cols = [x.name for x in plate_meta.plate.columns]
+    rows = sorted([x.name for x in plate_meta.plate.rows])
+    cols = sorted([x.name for x in plate_meta.plate.columns], key=int)
 
     row = rows.index(row)
     col = cols.index(col)


### PR DESCRIPTION
Assign correct well index by first sorting rows and columns returned by `load_NgffPlateMeta()`. Closes #38 